### PR TITLE
Add YTT203 & YTT204 to check for unsafe version_info[0] & version_info.minor

### DIFF
--- a/flake8_2020.py
+++ b/flake8_2020.py
@@ -96,8 +96,8 @@ class Visitor(ast.NodeVisitor):
                 node.left.lineno, node.left.col_offset, YTT103,
             ))
         elif (
-                self._is_sys('version_info', node.left.value) and
                 isinstance(node.left, ast.Subscript) and
+                self._is_sys('version_info', node.left.value) and
                 isinstance(node.left.slice, ast.Index) and
                 isinstance(node.left.slice.value, ast.Num) and
                 node.left.slice.value.n == 1 and
@@ -109,8 +109,8 @@ class Visitor(ast.NodeVisitor):
                 node.lineno, node.col_offset, YTT203,
             ))
         elif (
-                self._is_sys('version_info', node.left.value) and
                 isinstance(node.left, ast.Attribute) and
+                self._is_sys('version_info', node.left.value) and
                 node.left.attr == 'minor' and
                 len(node.ops) == 1 and
                 isinstance(node.ops[0], (ast.Lt, ast.LtE, ast.Gt, ast.GtE)) and

--- a/tests/flake8_2020_test.py
+++ b/tests/flake8_2020_test.py
@@ -85,7 +85,6 @@ def test_py4_comparison_to_version_3(s):
 
 @pytest.mark.parametrize(
     's',
-
     (
         'import six\n'
         'if six.PY3:\n'
@@ -113,4 +112,32 @@ def test_py10_indexing_of_sys_version_string(s):
     assert results(s) == {
         '2:11: YTT301: `sys.version[0]` referenced (python10), use '
         '`sys.version_info`',
+    }
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'import sys\nsys.version_info[1] >= 5',
+        'from sys import version_info\nversion_info[1] < 6',
+    ),
+)
+def test_version_info_index_one(s):
+    assert results(s) == {
+        '2:0: YTT203: `sys.version_info[1]` compared to integer, compare '
+        '`sys.version_info` to tuple',
+    }
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'import sys\nsys.version_info.minor <= 7',
+        'from sys import version_info\nversion_info.minor > 8',
+    ),
+)
+def test_version_info_minor(s):
+    assert results(s) == {
+        '2:0: YTT204: `sys.version_info.minor` compared to integer, compare '
+        '`sys.version_info` to tuple',
     }


### PR DESCRIPTION
Fixes #8.

TODO:

* [ ] This looks for `ast.Lt, ast.LtE, ast.Gt, ast.GtE ` comparisons, because `version_info.major == 3 and version_info.minor == 5` is a safe check. What do you think?

* [x] There's mypy failures on `self._is_sys('version_info', node.left.value)`. How to fix those?

* [ ] I added these as two codes as they have different messages. Should they be combined?

* [ ] There's no `(pythonXX)` in the messages, because this affects minor versions. Should there be something in brackets?

* [ ] Update README
