### PR TITLE
Fix for Python 3.8: Use stdlib importlib.metadata 

### DIFF
--- a/flake8_2020.py
+++ b/flake8_2020.py
@@ -6,7 +6,11 @@ from typing import List
 from typing import Tuple
 from typing import Type
 
-import importlib_metadata
+try:
+    # Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 YTT101 = 'YTT101 `sys.version[:3]` referenced (python3.10), use `sys.version_info`'  # noqa: E501
 YTT102 = 'YTT102 `sys.version[2]` referenced (python3.10), use `sys.version_info`'  # noqa: E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 py_modules = flake8_2020
 install_requires =
     flake8>=3.7
-    importlib-metadata>=0.9
+    importlib-metadata>=0.9;python_version<="3.7"
 python_requires = >=3.6
 
 [options.entry_points]


### PR DESCRIPTION
Flake8-2020 doesn't work on Python 3.8 because `importlib_metadata` is a backport of `importlib.metadata` from the standard library in 3.8.

It fails like this (running tox on `3.8-dev`, Python 3.8.0b4+):

```
tests/flake8_2020_test.py:5: in <module>
    from flake8_2020 import Plugin
flake8_2020.py:9: in <module>
    import importlib_metadata
.tox/py38/lib/python3.8/site-packages/importlib_metadata/__init__.py:532: in <module>
    __version__ = version(__name__)
.tox/py38/lib/python3.8/site-packages/importlib_metadata/__init__.py:494: in version
    return distribution(distribution_name).version
.tox/py38/lib/python3.8/site-packages/importlib_metadata/__init__.py:467: in distribution
    return Distribution.from_name(distribution_name)
.tox/py38/lib/python3.8/site-packages/importlib_metadata/__init__.py:181: in from_name
    dists = resolver(DistributionFinder.Context(name=name))
<frozen importlib._bootstrap_external>:1385: in find_distributions
    ???
.tox/py38/lib/python3.8/re.py:275: in escape
    pattern = str(pattern, 'latin1')
E   TypeError: decoding to str: need a bytes-like object, Context found
```

https://travis-ci.org/hugovk/flake8-2020/builds/585264854


With this fix, here's an example of it (almost) passing:

https://travis-ci.org/hugovk/flake8-2020/builds/585272513

It fails because coverage's `--fail-under 100`. Should that be reduced to allow for this branching, or make it ignore it?
