### PR TITLE
Check for sys.version_info[0] != 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ you might also find an early build of [python3.10] useful
 | YTT202 | `six.PY3` referenced (python4)                         |
 | YTT203 | `sys.version_info[1]` compared to integer (python4)    |
 | YTT204 | `sys.version_info.minor` compared to integer (python4) |
+| YTT205 | `sys.version_info[0] != 3` referenced (python4)        |
 | YTT301 | `sys.version[0]` referenced (python10)                 |
 | YTT302 | `sys.version` compared to string (python10)            |
 | YTT303 | `sys.version[:1]` referenced (python10)                |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ you might also find an early build of [python3.10] useful
 | YTT202 | `six.PY3` referenced (python4)                         |
 | YTT203 | `sys.version_info[1]` compared to integer (python4)    |
 | YTT204 | `sys.version_info.minor` compared to integer (python4) |
-| YTT205 | `sys.version_info[0] != 3` referenced (python4)        |
 | YTT301 | `sys.version[0]` referenced (python10)                 |
 | YTT302 | `sys.version` compared to string (python10)            |
 | YTT303 | `sys.version[:1]` referenced (python10)                |

--- a/flake8_2020.py
+++ b/flake8_2020.py
@@ -97,26 +97,16 @@ class Visitor(ast.NodeVisitor):
                 isinstance(node.left.slice.value, ast.Num) and
                 node.left.slice.value.n == 0 and
                 len(node.ops) == 1 and
-                isinstance(node.ops[0], ast.Eq) and
+                isinstance(node.ops[0], (ast.Eq, ast.NotEq)) and
                 isinstance(node.comparators[0], ast.Num) and
                 node.comparators[0].n == 3
         ):
+            if isinstance(node.ops[0], ast.Eq):
+                code = YTT201
+            else:
+                code = YTT205
             self.errors.append((
-                node.left.lineno, node.left.col_offset, YTT201,
-            ))
-        elif (
-                isinstance(node.left, ast.Subscript) and
-                self._is_sys('version_info', node.left.value) and
-                isinstance(node.left.slice, ast.Index) and
-                isinstance(node.left.slice.value, ast.Num) and
-                node.left.slice.value.n == 0 and
-                len(node.ops) == 1 and
-                isinstance(node.ops[0], ast.NotEq) and
-                isinstance(node.comparators[0], ast.Num) and
-                node.comparators[0].n == 3
-        ):
-            self.errors.append((
-                node.left.lineno, node.left.col_offset, YTT205,
+                node.left.lineno, node.left.col_offset, code,
             ))
         elif (
                 self._is_sys('version', node.left) and

--- a/flake8_2020.py
+++ b/flake8_2020.py
@@ -19,7 +19,6 @@ YTT201 = 'YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`'
 YTT202 = 'YTT202 `six.PY3` referenced (python4), use `not six.PY2`'
 YTT203 = 'YTT203 `sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to tuple'  # noqa: E501
 YTT204 = 'YTT204 `sys.version_info.minor` compared to integer (python4), compare `sys.version_info` to tuple'  # noqa: E501
-YTT205 = 'YTT205 `sys.version_info[0] != 3` referenced (python4), use `== 2`'
 YTT301 = 'YTT301 `sys.version[0]` referenced (python10), use `sys.version_info`'  # noqa: E501
 YTT302 = 'YTT302 `sys.version` compared to string (python10), use `sys.version_info`'  # noqa: E501
 YTT303 = 'YTT303 `sys.version[:1]` referenced (python10), use `sys.version_info`'  # noqa: E501
@@ -101,12 +100,8 @@ class Visitor(ast.NodeVisitor):
                 isinstance(node.comparators[0], ast.Num) and
                 node.comparators[0].n == 3
         ):
-            if isinstance(node.ops[0], ast.Eq):
-                code = YTT201
-            else:
-                code = YTT205
             self.errors.append((
-                node.left.lineno, node.left.col_offset, code,
+                node.left.lineno, node.left.col_offset, YTT201,
             ))
         elif (
                 self._is_sys('version', node.left) and

--- a/flake8_2020.py
+++ b/flake8_2020.py
@@ -19,6 +19,7 @@ YTT201 = 'YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`'
 YTT202 = 'YTT202 `six.PY3` referenced (python4), use `not six.PY2`'
 YTT203 = 'YTT203 `sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to tuple'  # noqa: E501
 YTT204 = 'YTT204 `sys.version_info.minor` compared to integer (python4), compare `sys.version_info` to tuple'  # noqa: E501
+YTT205 = 'YTT205 `sys.version_info[0] != 3` referenced (python4), use `== 2`'
 YTT301 = 'YTT301 `sys.version[0]` referenced (python10), use `sys.version_info`'  # noqa: E501
 YTT302 = 'YTT302 `sys.version` compared to string (python10), use `sys.version_info`'  # noqa: E501
 YTT303 = 'YTT303 `sys.version[:1]` referenced (python10), use `sys.version_info`'  # noqa: E501
@@ -102,6 +103,20 @@ class Visitor(ast.NodeVisitor):
         ):
             self.errors.append((
                 node.left.lineno, node.left.col_offset, YTT201,
+            ))
+        elif (
+                isinstance(node.left, ast.Subscript) and
+                self._is_sys('version_info', node.left.value) and
+                isinstance(node.left.slice, ast.Index) and
+                isinstance(node.left.slice.value, ast.Num) and
+                node.left.slice.value.n == 0 and
+                len(node.ops) == 1 and
+                isinstance(node.ops[0], ast.NotEq) and
+                isinstance(node.comparators[0], ast.Num) and
+                node.comparators[0].n == 3
+        ):
+            self.errors.append((
+                node.left.lineno, node.left.col_offset, YTT205,
             ))
         elif (
                 self._is_sys('version', node.left) and

--- a/tests/flake8_2020_test.py
+++ b/tests/flake8_2020_test.py
@@ -93,26 +93,14 @@ def test_py310_string_comparison_of_1_char(s):
     (
         'import sys\nPY3 = sys.version_info[0] == 3',
         'from sys import version_info\nPY3 = version_info[0] == 3',
+        'import sys\nPY2 = sys.version_info[0] != 3',
+        'from sys import version_info\nPY2 = version_info[0] != 3',
     ),
 )
 def test_py4_comparison_to_version_3(s):
     assert results(s) == {
         '2:6: YTT201 `sys.version_info[0] == 3` referenced (python4), use '
         '`>=`',
-    }
-
-
-@pytest.mark.parametrize(
-    's',
-    (
-        'import sys\nsys.version_info[0] != 3',
-        'from sys import version_info\nversion_info[0] != 3',
-    ),
-)
-def test_py4_ne_comparison_to_version_3(s):
-    assert results(s) == {
-        '2:0: YTT205 `sys.version_info[0] != 3` referenced (python4), use '
-        '`== 2`',
     }
 
 

--- a/tests/flake8_2020_test.py
+++ b/tests/flake8_2020_test.py
@@ -105,6 +105,20 @@ def test_py4_comparison_to_version_3(s):
 @pytest.mark.parametrize(
     's',
     (
+        'import sys\nsys.version_info[0] != 3',
+        'from sys import version_info\nversion_info[0] != 3',
+    ),
+)
+def test_py4_ne_comparison_to_version_3(s):
+    assert results(s) == {
+        '2:0: YTT205 `sys.version_info[0] != 3` referenced (python4), use '
+        '`== 2`',
+    }
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         'import six\n'
         'if six.PY3:\n'
         '    print("3")\n',


### PR DESCRIPTION
I ran into some code which essentially does:

```python
if sys.version_info[0] != 2:
    print("Python 3")

if sys.version_info[0] != 3:
    print "Python 2"
```

That second one will trigger on Python 4 as well!

I added this as `YTT205` because it's similar to `YTT201`.