### PR TITLE
Require python3.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ py_modules = flake8_2020
 install_requires =
     flake8>=3.7
     importlib-metadata>=0.9;python_version<"3.8"
-python_requires = >=3.6
+python_requires = >=3.6.1
 
 [options.entry_points]
 flake8.extension =


### PR DESCRIPTION
[python 3 statement - 3.6.0](https://github.com/asottile/scratch/wiki/python-3-statement#360)

(due to broken `NamedTuple` in 3.6.0)

Committed via https://github.com/asottile/all-repos